### PR TITLE
Graceful handling for missing variables

### DIFF
--- a/src/Jeffijoe.MessageFormat.Tests/MessageFormatterFullIntegrationTests.cs
+++ b/src/Jeffijoe.MessageFormat.Tests/MessageFormatterFullIntegrationTests.cs
@@ -472,6 +472,9 @@ namespace Jeffijoe.MessageFormat.Tests
             var ex = Assert.Throws<VariableNotFoundException>(() => subject.FormatMessage(Pattern, new { }));
             Assert.Equal("UnreadCount", ex.MissingVariable);
 
+            actual = subject.FormatMessage(Pattern, new { }, true);
+            Assert.Equal("You have no unread messages today.", actual);
+
             actual = subject.FormatMessage(Pattern, new { UnreadCount = 1 });
             Assert.Equal("You have just one unread message today.", actual);
             actual = subject.FormatMessage(Pattern, new { UnreadCount = 2 });

--- a/src/Jeffijoe.MessageFormat.Tests/TestHelpers/FakeMessageFormatter.cs
+++ b/src/Jeffijoe.MessageFormat.Tests/TestHelpers/FakeMessageFormatter.cs
@@ -9,7 +9,7 @@ namespace Jeffijoe.MessageFormat.Tests.TestHelpers
     {
         public CustomValueFormatter? CustomValueFormatter { get; set; }
 
-        public string FormatMessage(string pattern, IReadOnlyDictionary<string, object?> argsMap) => pattern;
+        public string FormatMessage(string pattern, IReadOnlyDictionary<string, object?> argsMap, bool ignoreMissingVariables = false) => pattern;
 
         public string FormatMessage(string pattern, object args) => pattern;
     }

--- a/src/Jeffijoe.MessageFormat/IMessageFormatter.cs
+++ b/src/Jeffijoe.MessageFormat/IMessageFormatter.cs
@@ -35,7 +35,7 @@ namespace Jeffijoe.MessageFormat
         /// <returns>
         ///     The <see cref="string" />.
         /// </returns>
-        string FormatMessage(string pattern, IReadOnlyDictionary<string, object?> argsMap);
+        string FormatMessage(string pattern, IReadOnlyDictionary<string, object?> argsMap, bool ignoreMissingVariables = false);
 
         #endregion
     }

--- a/src/Jeffijoe.MessageFormat/MessageFormatter.cs
+++ b/src/Jeffijoe.MessageFormat/MessageFormatter.cs
@@ -222,7 +222,7 @@ public class MessageFormatter : IMessageFormatter
     /// <returns>
     ///     The <see cref="string" />.
     /// </returns>
-    public string FormatMessage(string pattern, IReadOnlyDictionary<string, object?> args)
+    public string FormatMessage(string pattern, IReadOnlyDictionary<string, object?> args, bool ignoreMissingVariables = false)
     {
         /*
          * We are assuming the formatters are ordered correctly
@@ -241,7 +241,7 @@ public class MessageFormatter : IMessageFormatter
 
                 var formatter = this.Formatters.GetFormatter(request);
 
-                if (args.TryGetValue(request.Variable, out var value) == false && formatter.VariableMustExist)
+                if (args.TryGetValue(request.Variable, out var value) == false && !ignoreMissingVariables && formatter.VariableMustExist)
                 {
                     throw new VariableNotFoundException(request.Variable);
                 }

--- a/src/Jeffijoe.MessageFormat/MessageFormatterExtensions.cs
+++ b/src/Jeffijoe.MessageFormat/MessageFormatterExtensions.cs
@@ -46,8 +46,8 @@ public static class MessageFormatterExtensions
     /// <returns>
     ///     The <see cref="string" />.
     /// </returns>
-    public static string FormatMessage(this IMessageFormatter formatter, string pattern, object args)
+    public static string FormatMessage(this IMessageFormatter formatter, string pattern, object args, bool ignoreMissingVariables = false)
     {
-        return formatter.FormatMessage(pattern, args.ToDictionary());
+        return formatter.FormatMessage(pattern, args.ToDictionary(), ignoreMissingVariables);
     }
 }


### PR DESCRIPTION
This is so older strings and setups do not throw lots of exceptions